### PR TITLE
Create frontend.jsx | Graphite Demo

### DIFF
--- a/graphite-demo/frontend.jsx
+++ b/graphite-demo/frontend.jsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from 'react';
+
+const TaskSearch = () => {
+  const [tasks, setTasks] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(`/search?query=${encodeURIComponent(searchQuery)}`)
+      .then(response => {
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+        return response.json();
+      })
+      .then(data => {
+        setTasks(data);
+        setLoading(false);
+      })
+      .catch(error => {
+        setError(error.message);
+        setLoading(false);
+      });
+  }, [searchQuery]); // Depend on searchQuery
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error}</div>;
+  }
+
+  return (
+    <div>
+      <h2>Task Search</h2>
+      <input
+        type="text"
+        placeholder="Search tasks..."
+        value={searchQuery}
+        onChange={(e) => setSearchQuery(e.target.value)}
+      />
+      <ul>
+        {tasks.map(task => (
+          <li key={task.id}>
+            <p>{task.description}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default TaskSearch;


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`02-16-demo_58216336_add_server_api`]() into [`main`](https://github.com/Atomic-Atlas/MaS/tree/main).

### In-depth Details
- This PR contains one commit:
     1. ["Create frontend.jsx"](https://github.com/Nicole-Scalera/chirp/commit/aa2753a0c7ef7e6185660403352cf75b07ede5b0) | (aa2753a)
- It is from a CLI demo for [Graphite](https://graphite.dev/), a software whose tools I first introduced in #5.
- Graphite is built around a "stacking" workflow, which I discussed in-depth [here](https://github.com/Nicole-Scalera/sandbox/pull/3).
- Run the stacking [demo](https://graphite.dev/docs/command-reference#gt-demo-demoname) with the following line: `$ gt demo stack`.

<p>
<img src="https://github.com/user-attachments/assets/bdea2baf-03a0-423b-9bb4-6ac995f9ffe2" alt="gt demo CLI command" width="100%" style="max-width: 100%;">
</p>

- I am merging the changes from this demo (performed in the CLI) into main so I can begin practicing the stacking features, before utilizing them in my other repos.