### PR TITLE
Updated Employee.java | Multi-line Message 1

### DIFF
--- a/Graphite/Better Commit Messages/Employee.java
+++ b/Graphite/Better Commit Messages/Employee.java
@@ -5,35 +5,47 @@ public class Employee {
   public static void main(String[] args) {
 
     // Create a variable called age of type int and assign it the value 29.
+    int age = 29;
 
     // Print the age variable to the console.
+    System.out.println(age);
 
     // Create a variable called isAManager of type boolean and assign it the value
     // true.
+    boolean isAManager = true;
 
     // Print the isAManager variable to the console.
+    System.out.println(isAManager);
 
     // Create a variable called yearsOfService of type double and assign it the
     // value 2.5.
+    double yearsOfService = 2.5;
 
     // Print the yearsOfService variable to the console.
+    System.out.println(yearsOfService);
 
     // Create a variable called baseSalary of type int and assign it the value 3000.
+    int baseSalary = 3000;
 
     // Create a variable called overtimePayment of type int and assign it the value
     // 40.
+    int overtimePayment = 40;
 
     // Create a variable called totalPayment of type int and assign it to the value
     // of baseSalary added to overtimePayment.
+    int totalPayment = baseSalary + overtimePayment;
 
     // Print the totalPayment variable to the console.
+    System.out.println(totalPayment);
 
     // Create three variables all of type double on a single line.
     // They should be called firstBonus, secondBonus and thirdBonus and they should
     // be assigned the values 10.00, 22.00 and 35.00.
+    double firstBonus = 10.00, secondBonus = 22.00, thirdBonus = 35.00;
 
     // Print out the sum of the variables called firstBonus, secondBonus and
     // thirdBonus.
+    System.out.println(firstBonus + secondBonus + thirdBonus);
 
   }
 


### PR DESCRIPTION
### Overview
- Updated Employee.java from the first commit (504628e).
- Established working usage of multi-line commit messages with Graphite.

### In-depth Details
- As explained [last commit](https://github.com/Nicole-Scalera/chirp/commit/504628e0ebfab13736e1f855cecab769698deb20), this file regards the experimentation of multi-line commit messages through the Graphite CLI.
- In this commit, I updated Employee.java with the changes from Nicole-Scalera/sandbox@0c84cd9.
- With git, you can usually just do:
> `git commit -m "Commit Title" -m "Commit description."`
- However, Graphite seems to only support the following when committing changes to a new stack:
> `gt create -m "Commit message" branch/name`
- My first instinct was to use the `\n` linebreak, but that just gave me this.

<p>
<img src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ufEW4QhHtEPyl890DHB9/d214de7c-58be-4182-868b-22c1b2f784f3.png" alt="Multi-line Message Failure" width="80%" style="max-width: 100%;">
</p>

- I played around with this some more and realized I could use single quotes to create line breaks, while still technically adding everything in one commit message.
- That being said, the commit message now appears as intended.

<p>
<img src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ufEW4QhHtEPyl890DHB9/ffe9d172-8b4c-4185-8010-26500485d222.png" alt="Successful Commit Message" width="80%" style="max-width: 100%;">
</p>

- However, I will likely still need to test its capabilities when using descriptions that also contain single quotes ('), usually from contractions like _I'm_ or _there's_ or _it's_.